### PR TITLE
Update the gauge creation to allow for refreshing

### DIFF
--- a/src/ng-justgage.js
+++ b/src/ng-justgage.js
@@ -1,29 +1,31 @@
 angular.module("ngJustGage", [])
-  .directive('justGage', function ($compile, $timeout) {
-    return {
-      restrict: 'E',
-        scope: { 
-          id: '@',
-          min: '=',
-          max: '=', 
-          title: '@',
-          value: '=' 
-	},
-	template: '<div id={{id}}-justgage></div>',
-        compile: function (element, attrs, transclude) {     
-          return {
-            post: function (scope, element, attrs, controller) {
-              $timeout(function() {
-                var g = new JustGage({
-                  id: scope.id + '-justgage',
-                  min: scope.min,
-                  max: scope.max,
-                  title: scope.title,
-                  value: scope.value
-                });
+  .directive('justGage', function ($timeout) {
+      return {
+          restrict: 'E',
+          scope: {
+              id: '@',
+              min: '=',
+              max: '=',
+              title: '@',
+              value: '='
+          },
+          template: '<div id={{id}}-justgage></div>',
+          link: function (scope) {
+              $timeout(function () {
+                  var g = new JustGage({
+                      id: scope.id + '-justgage',
+                      min: scope.min,
+                      max: scope.max,
+                      title: scope.title,
+                      value: scope.value
+                  })
+
+                  scope.$watch('value', function (updatedValue) {
+                      if (updatedValue) {
+                          g.refresh(updatedValue)
+                      }
+                  }, true);
               });
-            }
-          };
-        }
-    };
+          }
+      };
   });


### PR DESCRIPTION
Currently works beautifully for static data.  This suggested update allows binding of a value using `value="item.value"`.  When the value is updated, the JustGage is refreshed to reflect the new value
