### PR TITLE
Add options attribute to pass a complete options list to directive

### DIFF
--- a/ng-justgage.js
+++ b/ng-justgage.js
@@ -8,18 +8,25 @@ angular.module("ngJustGage", [])
         min: '=',
         max: '=',
         title: '@',
-        value: '='
+        value: '=',
+        options: '='
       },
       template: '<div id="{{id}}-justgage" class="{{class}}"></div>',
-      link: function (scope) {
+      link: function (scope,element,attrs) {
         $timeout(function () {
-          var graph = new JustGage({
+          var options = {
             id: scope.id + '-justgage',
             min: scope.min,
             max: scope.max,
             title: scope.title,
             value: scope.value
-          });
+          }
+          if ( scope.options ) {
+              for (var key in scope.options) {
+                  options[key]=scope.options[key];
+              }
+          }
+          var graph = new JustGage(options);
 
           scope.$watch('max', function (updatedMax) {
             if (updatedMax) {


### PR DESCRIPTION
The option attribute must contains an object with the additional options
you want to pass to the justgage object. Normal option are still use but
will be overload by object if declared twice.

Here's a sample to use levelColors and levelGradiant.
All justgage option are now available for the directive.

```
    <just-gage
        id="demo"
        class=""
        min=0 max=100 value="92"
        title="Demo"
        options="{
            levelColors: ['#CE1B21', '#D0532A', '#FFC414', '#85A137']
            ,levelGradiant: false
        }
        ">
    </just-gage>
```
